### PR TITLE
Unicode Support

### DIFF
--- a/petulantbear/netcdf_etree.py
+++ b/petulantbear/netcdf_etree.py
@@ -25,7 +25,7 @@ a lxml tree which allows the user to query and modify a NetCDF4 dataset using th
 interface.
 '''
 
-import cStringIO
+import StringIO
 from lxml import etree
 from netcdf2ncml import *
 
@@ -434,14 +434,14 @@ class NetCDFLookup(etree.CustomElementClassLookup):
         
 def parse_nc_dataset_as_etree(dataset):
 
-    parser = etree.XMLParser()
+    parser = etree.XMLParser(encoding='UTF-8')
     parser.set_element_class_lookup(NetCDFLookup())
 
     xml_etree = None
-    output = cStringIO.StringIO()
+    output = StringIO.StringIO()
     try:
         dataset2ncml_buffer(dataset,output)
-        output.reset()
+        output.seek(0)
         xml_etree = etree.parse(output, parser)
     finally:
         output.close()


### PR DESCRIPTION
NetCDF supports unicode characters (no encoding specified though -_-)
From the standard:
  Note on char data: Although the characters used in netCDF names must
  be encoded as UTF-8, character data may use other encodings. The
  variable attribute “_Encoding” is reserved for this purpose in future
  implementations.

This adds some degree of unicode support to petulant bear.
What still needs to be done is determining proper character encodings.
